### PR TITLE
[FIX:] Fix creation templates for C and C++ projects

### DIFF
--- a/src/nester/core/templates/c/c_layout.json
+++ b/src/nester/core/templates/c/c_layout.json
@@ -1,11 +1,11 @@
 {
   "$projectname": {
     "include": {
-      "my_header.h": "#ifndef MY_HEADER_H\n#define MY_HEADER_H\n\nvoid my_function();\n\n#endif /* MY_HEADER_H */"
+      "$projectname.h": "#ifndef MY_HEADER_H\n#define MY_HEADER_H\n\nvoid my_function();\n\n#endif /* MY_HEADER_H */"
     },
     "src": {
       "main.c": "#include <stdio.h>\n#include \"my_header.h\"\n\nint main() {\n  /* Default method implementation */\n  return 0;\n}",
-      "my_source.c": "#include \"my_header.h\"\n\nvoid my_function() {\n  /* Default method implementation */\n  return 0;\n}"
+      "$projectname.c": "#include \"my_header.h\"\n\nvoid my_function() {\n  /* Default method implementation */\n  return 0;\n}"
     },
     "Makefile": ""
   },

--- a/src/nester/core/templates/cpp/cpp_layout.json
+++ b/src/nester/core/templates/cpp/cpp_layout.json
@@ -5,10 +5,10 @@
     },
     "src": {
       "main.cpp": "#include <iostream>\n#include \"${projectname}_header.hpp\"\n\nint main() {\n  /* Default method implementation */\n  return 0;\n}",
-      "my_source.cpp": "#include \"${projectname}_header.hpp\"\n\nvoid my_function() {\n  /* Default method implementation */\n  return 0;\n}"
+      "$projectname_source.cpp": "#include \"${projectname}_header.hpp\"\n\nvoid my_function() {\n  /* Default method implementation */\n  return 0;\n}"
     },
     "tests": {
-      "my_test.test.cpp": "#include <gtest/gtest.h>\n#include \"${projectname}_header.hpp\"\n\ntest(MyTest, TestFunction) {\n  /* Default test implementation */\n}"
+      "$projectname.test.cpp": "#include <gtest/gtest.h>\n#include \"${projectname}_header.hpp\"\n\ntest(MyTest, TestFunction) {\n  /* Default test implementation */\n}"
     }
   },
   "README": "<!--Your Readme goes here-->",


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

Up until now the template for C and C++ projects did not correctly inject the given projectname for header and source files. This is fixed now.

Tick the applicable box:
- [ ] Add new feature
- [x] Fixed feature
- [ ] Add language support
- [ ] UI improvement
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## UI changes

<!-- provide description here or remove all unapplicable lines below -->

- No changes

 - [x] DONE

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: 

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE
