### PR TITLE
Update buildsystem configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ dynamic = [
   "keywords",
   "license",
   "classifiers",
-  "version"
+  "version",
+  "readme",
+  "dependencies",
+  "optional-dependencies"
 ]
 
 [project.scripts]

--- a/src/nester/__init__.py
+++ b/src/nester/__init__.py
@@ -2,4 +2,4 @@
 Main Nester package.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"


### PR DESCRIPTION
# What does this PR change?

<!-- provide a short description what exactly your PR changes here -->

According to pip, to build a python application using the hybrid `pyproject.toml` and `setup.py` approach, everything listed in the `setup.cfg` now has to be listed as `dynamic` in the `pyproject.toml`.

This is the error message that states the information. The provided link however is broken.

```
********************************************************************************
              The following seems to be defined outside of `pyproject.toml`:
      
              `dependencies = ['setuptools>=65.5.0', 'wheel>=0.37.1', 'click>=8.1.3', 'questionary>=1.10.0']`
      
              According to the spec (see the link below), however, setuptools CANNOT
              consider this value unless `dependencies` is listed as `dynamic`.
      
              https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
      
              To prevent this problem, you can list `dependencies` under `dynamic` or alternatively
              remove the `[project]` table from your file and rely entirely on other means of
              configuration.
********************************************************************************
```

Tick the applicable box:
- [ ] Add new feature
- [ ] Add language support
- [ ] UI improvement
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [x] General Maintenance

## UI changes

<!-- provide description here or remove all unapplicable lines below -->

- No changes

 - [x] DONE

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: N/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE
